### PR TITLE
Optimize clear method

### DIFF
--- a/src/main/java/com/qiukeke/mybatis/plugins/MySQLLimitPlugin.java
+++ b/src/main/java/com/qiukeke/mybatis/plugins/MySQLLimitPlugin.java
@@ -64,6 +64,12 @@ public class MySQLLimitPlugin extends PluginAdapter {
         getOffset.addBodyLine("return offset;");
         topLevelClass.addMethod(getOffset);
 
+        for (Method method : topLevelClass.getMethods()) {
+            if ("clear".equals(method.getName())) {
+                method.addBodyLine("offset = null;");
+                method.addBodyLine("limit = null;");
+            }
+        }
         return true;
     }
 


### PR DESCRIPTION
**优化生成的clear方法**

原来生成的clear方法如下：
```
public void clear() {
        oredCriteria.clear();
        orderByClause = null;
        distinct = false;
    }
```
但是我们加入limit、offset属性、希望XXXExample#clear调用也可以清除，
这里做了点小修改，最终效果：
```
public void clear() {
        oredCriteria.clear();
        orderByClause = null;
        distinct = false;
        offset = null;
        limit = null;
    }
```

@qiukeren 可以看下这样是否有意义，如果可以帮忙合并下发布到maven仓库？